### PR TITLE
feat!: add update strategy handling and stashing functionality in Intaller

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,53 @@ By default, modules are installed under `Modules/` at the project root. You can 
 
 With the configuration above, a module published as `saucebase/example-module` installs to `MyModules/ExampleModule`.
 
+## Configuring Update Behaviour
+
+By default, when you run `composer update`, the installer **merges** the new package version into
+your existing module directory rather than replacing it. Your customised files are preserved; any
+new files shipped in the update are added on top.
+
+| Strategy | What happens on `composer update` |
+|---|---|
+| `merge` *(default)* | Existing module files are kept. New files from the package are added. Your edits always win. |
+| `overwrite` | The module directory is replaced entirely with the new package contents. All local changes are lost. |
+
+### Keeping your customisations (default)
+
+No configuration is needed. The `merge` strategy is active by default. Running `composer update`
+will add any new files the package ships without touching files you have already edited.
+
+> **Note:** Because your local files always take precedence, bug fixes or updates to files you have
+> customised will **not** be applied automatically. To pick up an upstream change to a specific
+> file, replace it manually or delete it and re-run `composer update`.
+
+### Full overwrite (CI / reproducible builds)
+
+If you want every `composer update` to produce an exact copy of the package — discarding any
+local edits — set the strategy to `overwrite` in your root `composer.json`:
+
+```json
+{
+    "extra": {
+        "module-update-strategy": "overwrite"
+    }
+}
+```
+
+This is recommended for CI pipelines and staging environments where reproducibility matters more
+than preserving local changes.
+
+### Getting a completely fresh copy of a module
+
+With the `merge` strategy (default), delete the module directory and run `composer update`:
+
+```bash
+rm -rf Modules/ExampleModule
+composer update vendor/example-module
+```
+
+The installer will perform a clean install into the now-empty path.
+
 ## Creating Sauce Base Modules
 
 To ship a module that works with this installer:

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -4,9 +4,16 @@ namespace Saucebase\ModuleInstaller;
 
 use Composer\Installer\LibraryInstaller;
 use Composer\Package\PackageInterface;
+use Composer\Repository\InstalledRepositoryInterface;
 use Composer\Util\Filesystem;
+use React\Promise\PromiseInterface;
 use Saucebase\ModuleInstaller\Exceptions\ModuleInstallerException;
+use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
 
+/**
+ * @property \Composer\PartialComposer $composer
+ * @property \Composer\IO\IOInterface  $io
+ */
 class Installer extends LibraryInstaller
 {
     const DEFAULT_ROOT = 'Modules';
@@ -14,6 +21,12 @@ class Installer extends LibraryInstaller
     const DEFAULT_MODULE_TYPE = 'laravel-module';
 
     const DEFAULT_EXCLUDED_DIRS = ['.github', '.git'];
+
+    const DEFAULT_UPDATE_STRATEGY = 'merge';
+
+    const UPDATE_STRATEGY_MERGE = 'merge';
+
+    const UPDATE_STRATEGY_OVERWRITE = 'overwrite';
 
     public function getInstallPath(PackageInterface $package)
     {
@@ -133,11 +146,83 @@ class Installer extends LibraryInstaller
     }
 
     /**
+     * Get the update strategy to use when updating a module.
+     * Defaults to 'merge' and can be overridden via extra['module-update-strategy'].
+     *
+     * @return string
+     */
+    protected function getUpdateStrategy(): string
+    {
+        if (! $this->composer || ! $this->composer->getPackage()) {
+            return self::DEFAULT_UPDATE_STRATEGY;
+        }
+
+        $extra = $this->composer->getPackage()->getExtra();
+
+        if (! $extra || empty($extra['module-update-strategy'])) {
+            return self::DEFAULT_UPDATE_STRATEGY;
+        }
+
+        $strategy = $extra['module-update-strategy'];
+        $allowed = [self::UPDATE_STRATEGY_MERGE, self::UPDATE_STRATEGY_OVERWRITE];
+
+        if (! in_array($strategy, $allowed, true)) {
+            $this->io->writeError(
+                sprintf(
+                    '  <warning>Invalid module-update-strategy "%s". Falling back to "%s".</warning>',
+                    $strategy,
+                    self::DEFAULT_UPDATE_STRATEGY
+                )
+            );
+
+            return self::DEFAULT_UPDATE_STRATEGY;
+        }
+
+        return $strategy;
+    }
+
+    /**
+     * Rename the module directory to a temp location and return the temp path.
+     * Returns null if the directory does not exist.
+     *
+     * @param  string  $path
+     * @return string|null
+     */
+    protected function stashModuleDir(string $path): ?string
+    {
+        if (! is_dir($path)) {
+            return null;
+        }
+
+        $stash = sys_get_temp_dir().'/module-stash-'.uniqid('', true);
+        (new SymfonyFilesystem)->rename($path, $stash);
+
+        return $stash;
+    }
+
+    /**
+     * Mirror the stash directory back into the install path so user edits win.
+     *
+     * @param  string  $stashPath
+     * @param  string  $installPath
+     * @return void
+     */
+    protected function restoreStash(string $stashPath, string $installPath): void
+    {
+        (new SymfonyFilesystem)->mirror(
+            $stashPath,
+            $installPath,
+            null,
+            ['override' => true, 'delete' => false]
+        );
+    }
+
+    /**
      * Override install to remove excluded directories after installation.
      *
      * {@inheritDoc}
      */
-    public function install(\Composer\Repository\InstalledRepositoryInterface $repo, PackageInterface $package)
+    public function install(InstalledRepositoryInterface $repo, PackageInterface $package): PromiseInterface|null
     {
         $promise = parent::install($repo, $package);
 
@@ -147,16 +232,34 @@ class Installer extends LibraryInstaller
     }
 
     /**
-     * Override update to remove excluded directories after update.
+     * Override update to preserve user customisations (merge strategy) or replace entirely (overwrite).
      *
      * {@inheritDoc}
      */
-    public function update(\Composer\Repository\InstalledRepositoryInterface $repo, PackageInterface $initial, PackageInterface $target)
+    public function update(InstalledRepositoryInterface $repo, PackageInterface $initial, PackageInterface $target): PromiseInterface|null
     {
+        $stashPath = null;
+
+        if ($this->getUpdateStrategy() === self::UPDATE_STRATEGY_MERGE) {
+            $stashPath = $this->stashModuleDir($this->getInstallPath($initial));
+        }
+
         $promise = parent::update($repo, $initial, $target);
 
-        return $promise->then(function () use ($target) {
-            $this->removeExcludedDirectories($target);
-        });
+        return $promise->then(
+            function () use ($target, $stashPath) {
+                $this->removeExcludedDirectories($target);
+                if ($stashPath !== null) {
+                    $this->restoreStash($stashPath, $this->getInstallPath($target));
+                    (new Filesystem)->removeDirectory($stashPath);
+                }
+            },
+            function (\Throwable $e) use ($stashPath) {
+                if ($stashPath !== null) {
+                    (new Filesystem)->removeDirectory($stashPath);
+                }
+                throw $e;
+            }
+        );
     }
 }

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -3,7 +3,9 @@
 namespace Saucebase\ModuleInstaller;
 
 use Composer\Installer\LibraryInstaller;
+use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
+use Composer\PartialComposer;
 use Composer\Repository\InstalledRepositoryInterface;
 use Composer\Util\Filesystem;
 use React\Promise\PromiseInterface;
@@ -11,8 +13,8 @@ use Saucebase\ModuleInstaller\Exceptions\ModuleInstallerException;
 use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
 
 /**
- * @property \Composer\PartialComposer $composer
- * @property \Composer\IO\IOInterface  $io
+ * @property PartialComposer $composer
+ * @property IOInterface $io
  */
 class Installer extends LibraryInstaller
 {
@@ -148,8 +150,6 @@ class Installer extends LibraryInstaller
     /**
      * Get the update strategy to use when updating a module.
      * Defaults to 'merge' and can be overridden via extra['module-update-strategy'].
-     *
-     * @return string
      */
     protected function getUpdateStrategy(): string
     {
@@ -184,9 +184,6 @@ class Installer extends LibraryInstaller
     /**
      * Rename the module directory to a temp location and return the temp path.
      * Returns null if the directory does not exist.
-     *
-     * @param  string  $path
-     * @return string|null
      */
     protected function stashModuleDir(string $path): ?string
     {
@@ -202,10 +199,6 @@ class Installer extends LibraryInstaller
 
     /**
      * Mirror the stash directory back into the install path so user edits win.
-     *
-     * @param  string  $stashPath
-     * @param  string  $installPath
-     * @return void
      */
     protected function restoreStash(string $stashPath, string $installPath): void
     {
@@ -222,7 +215,7 @@ class Installer extends LibraryInstaller
      *
      * {@inheritDoc}
      */
-    public function install(InstalledRepositoryInterface $repo, PackageInterface $package): PromiseInterface|null
+    public function install(InstalledRepositoryInterface $repo, PackageInterface $package): ?PromiseInterface
     {
         $promise = parent::install($repo, $package);
 
@@ -236,7 +229,7 @@ class Installer extends LibraryInstaller
      *
      * {@inheritDoc}
      */
-    public function update(InstalledRepositoryInterface $repo, PackageInterface $initial, PackageInterface $target): PromiseInterface|null
+    public function update(InstalledRepositoryInterface $repo, PackageInterface $initial, PackageInterface $target): ?PromiseInterface
     {
         $stashPath = null;
 

--- a/tests/ModuleInstallerTest.php
+++ b/tests/ModuleInstallerTest.php
@@ -33,6 +33,21 @@ final class TestableInstaller extends Installer
     {
         return parent::getBaseInstallationPath();
     }
+
+    public function callGetUpdateStrategy(): string
+    {
+        return parent::getUpdateStrategy();
+    }
+
+    public function callStashModuleDir(string $path): ?string
+    {
+        return parent::stashModuleDir($path);
+    }
+
+    public function callRestoreStash(string $from, string $to): void
+    {
+        parent::restoreStash($from, $to);
+    }
 }
 
 final class ModuleInstallerTest extends TestCase
@@ -118,5 +133,133 @@ final class ModuleInstallerTest extends TestCase
 
         $this->expectException(ModuleInstallerException::class);
         $installer->callGetModuleName($bad);
+    }
+
+    // -------------------------------------------------------------------------
+    // getUpdateStrategy
+    // -------------------------------------------------------------------------
+
+    public function test_get_update_strategy_returns_merge_by_default(): void
+    {
+        $io = $this->createMock(IOInterface::class);
+        $installer = new TestableInstaller($io, null);
+
+        $this->assertSame('merge', $installer->callGetUpdateStrategy());
+    }
+
+    public function test_get_update_strategy_returns_overwrite_when_configured(): void
+    {
+        $io = $this->createMock(IOInterface::class);
+        $composer = $this->createMock(Composer::class);
+
+        $root = new RootPackage('root/app', '1.0.0.0', '1.0.0');
+        $root->setExtra(['module-update-strategy' => 'overwrite']);
+        $composer->method('getPackage')->willReturn($root);
+
+        $installer = new TestableInstaller($io, $composer);
+
+        $this->assertSame('overwrite', $installer->callGetUpdateStrategy());
+    }
+
+    public function test_get_update_strategy_falls_back_on_invalid_value_and_warns(): void
+    {
+        $io = $this->createMock(IOInterface::class);
+        $io->expects($this->once())->method('writeError');
+
+        $composer = $this->createMock(Composer::class);
+
+        $root = new RootPackage('root/app', '1.0.0.0', '1.0.0');
+        $root->setExtra(['module-update-strategy' => 'bogus']);
+        $composer->method('getPackage')->willReturn($root);
+
+        $installer = new TestableInstaller($io, $composer);
+
+        $this->assertSame('merge', $installer->callGetUpdateStrategy());
+    }
+
+    // -------------------------------------------------------------------------
+    // stashModuleDir
+    // -------------------------------------------------------------------------
+
+    public function test_stash_renames_dir_to_temp_location(): void
+    {
+        $io = $this->createMock(IOInterface::class);
+        $installer = new TestableInstaller($io, null);
+
+        $source = sys_get_temp_dir().'/module-stash-test-src-'.uniqid('', true);
+        mkdir($source);
+        file_put_contents($source.'/custom.txt', 'hello');
+
+        $stash = $installer->callStashModuleDir($source);
+
+        $this->assertNotNull($stash);
+        $this->assertDirectoryDoesNotExist($source);
+        $this->assertDirectoryExists($stash);
+        $this->assertFileExists($stash.'/custom.txt');
+
+        // Cleanup
+        (new \Symfony\Component\Filesystem\Filesystem)->remove($stash);
+    }
+
+    public function test_stash_returns_null_when_dir_does_not_exist(): void
+    {
+        $io = $this->createMock(IOInterface::class);
+        $installer = new TestableInstaller($io, null);
+
+        $this->assertNull($installer->callStashModuleDir('/nonexistent/path/'.uniqid('', true)));
+    }
+
+    // -------------------------------------------------------------------------
+    // restoreStash
+    // -------------------------------------------------------------------------
+
+    public function test_restore_stash_copies_user_files_into_install_path(): void
+    {
+        $io = $this->createMock(IOInterface::class);
+        $installer = new TestableInstaller($io, null);
+
+        $stash = sys_get_temp_dir().'/module-stash-test-restore-'.uniqid('', true);
+        $install = sys_get_temp_dir().'/module-install-test-'.uniqid('', true);
+
+        mkdir($stash);
+        mkdir($install);
+        file_put_contents($stash.'/custom.txt', 'user edit');
+
+        $installer->callRestoreStash($stash, $install);
+
+        $this->assertFileExists($install.'/custom.txt');
+        $this->assertSame('user edit', file_get_contents($install.'/custom.txt'));
+
+        // Cleanup
+        $fs = new \Symfony\Component\Filesystem\Filesystem;
+        $fs->remove($stash);
+        $fs->remove($install);
+    }
+
+    public function test_restore_stash_leaves_new_upstream_files_intact(): void
+    {
+        $io = $this->createMock(IOInterface::class);
+        $installer = new TestableInstaller($io, null);
+
+        $stash = sys_get_temp_dir().'/module-stash-test-upstream-'.uniqid('', true);
+        $install = sys_get_temp_dir().'/module-install-test-upstream-'.uniqid('', true);
+
+        mkdir($stash);
+        mkdir($install);
+
+        // Upstream added a new file during update
+        file_put_contents($install.'/new-upstream.txt', 'new from upstream');
+        // User had a customised file in the stash
+        file_put_contents($stash.'/custom.txt', 'user edit');
+
+        $installer->callRestoreStash($stash, $install);
+
+        $this->assertFileExists($install.'/new-upstream.txt');
+        $this->assertFileExists($install.'/custom.txt');
+
+        // Cleanup
+        $fs = new \Symfony\Component\Filesystem\Filesystem;
+        $fs->remove($stash);
+        $fs->remove($install);
     }
 }

--- a/tests/ModuleInstallerTest.php
+++ b/tests/ModuleInstallerTest.php
@@ -9,9 +9,11 @@ use Composer\IO\IOInterface;
 use Composer\Package\Package;
 use Composer\Package\PackageInterface;
 use Composer\Package\RootPackage;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Saucebase\ModuleInstaller\Exceptions\ModuleInstallerException;
 use Saucebase\ModuleInstaller\Installer;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Shim that avoids LibraryInstaller's heavy constructor.
@@ -127,7 +129,7 @@ final class ModuleInstallerTest extends TestCase
         $composer = $this->createMock(Composer::class);
         $installer = new TestableInstaller($io, $composer);
 
-        /** @var \PHPUnit\Framework\MockObject\MockObject&PackageInterface $bad */
+        /** @var MockObject&PackageInterface $bad */
         $bad = $this->createMock(PackageInterface::class);
         $bad->method('getPrettyName')->willReturn('invalidname'); // no slash
 
@@ -198,7 +200,7 @@ final class ModuleInstallerTest extends TestCase
         $this->assertFileExists($stash.'/custom.txt');
 
         // Cleanup
-        (new \Symfony\Component\Filesystem\Filesystem)->remove($stash);
+        (new Filesystem)->remove($stash);
     }
 
     public function test_stash_returns_null_when_dir_does_not_exist(): void
@@ -231,7 +233,7 @@ final class ModuleInstallerTest extends TestCase
         $this->assertSame('user edit', file_get_contents($install.'/custom.txt'));
 
         // Cleanup
-        $fs = new \Symfony\Component\Filesystem\Filesystem;
+        $fs = new Filesystem;
         $fs->remove($stash);
         $fs->remove($install);
     }
@@ -258,7 +260,7 @@ final class ModuleInstallerTest extends TestCase
         $this->assertFileExists($install.'/custom.txt');
 
         // Cleanup
-        $fs = new \Symfony\Component\Filesystem\Filesystem;
+        $fs = new Filesystem;
         $fs->remove($stash);
         $fs->remove($install);
     }


### PR DESCRIPTION
This pull request introduces a configurable update strategy for module installations, allowing users to choose between merging updates (preserving local customisations) or overwriting modules (ensuring reproducibility). The implementation includes new logic in the installer, comprehensive documentation, and thorough tests for the new behaviours.

## Update strategy feature

* Added support for configurable update strategies (`merge` or `overwrite`) via `extra['module-update-strategy']` in `composer.json`, with `merge` as the default. The installer now checks this configuration and applies the appropriate strategy during updates. [[1]](diffhunk://#diff-67306479da293f095927542c4cff1a45875138eb52372caaba982b07c053285bR25-R30) [[2]](diffhunk://#diff-67306479da293f095927542c4cff1a45875138eb52372caaba982b07c053285bR148-R225) [[3]](diffhunk://#diff-67306479da293f095927542c4cff1a45875138eb52372caaba982b07c053285bL150-R263)
* Implemented helper methods in `Installer` to stash and restore module directories, ensuring user customisations are preserved when using the `merge` strategy.

## Documentation

* Updated `README.md` with a detailed explanation of update strategies, including a comparison table, usage instructions, and recommendations for CI/staging environments.

## Testing

* Added new tests in `ModuleInstallerTest.php` to verify correct behaviour for update strategy selection, directory stashing/restoration, and handling of invalid strategy values. [[1]](diffhunk://#diff-1c4ad9a794cc3c9de41e4cd7aba567b1d603958a8a1fb12f0065968951af319bR36-R50) [[2]](diffhunk://#diff-1c4ad9a794cc3c9de41e4cd7aba567b1d603958a8a1fb12f0065968951af319bR137-R264)