### PR TITLE
Implement merge conflict handling and restore module directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "name": "saucebase/module-installer",
+  "version": "1.0.1",
   "description": "Custom Composer installer for Sauce Base modules (type: saucebase-module). Installs to Modules/<Name> with configurable base dir.",
   "type": "composer-plugin",
   "license": "MIT",
@@ -12,8 +13,8 @@
   "require": {
     "php": "^8.4",
     "composer-plugin-api": "^2.0",
-    "symfony/finder": "^8.0",
-    "symfony/process": "^8.0"
+    "symfony/finder": "^7.0 || ^8.0",
+    "symfony/process": "^7.0 || ^8.0"
   },
   "require-dev": {
     "composer/composer": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3b9bd3ebf86ea0e34b28472b9de4c0f3",
+    "content-hash": "b94f7fab44f8be2c33979a864196f3a4",
     "packages": [
         {
             "name": "symfony/finder",

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -184,6 +184,20 @@ class Installer extends LibraryInstaller
     }
 
     /**
+     * Restore a stashed module directory back to its original install path.
+     * If the original path was re-created (e.g. by a partial update), the stash is discarded.
+     */
+    protected function restoreStash(string $stashPath, PackageInterface $package): void
+    {
+        $originalPath = $this->getInstallPath($package);
+        if (! is_dir($originalPath)) {
+            (new SymfonyFilesystem)->rename($stashPath, $originalPath);
+        } else {
+            (new Filesystem)->removeDirectory($stashPath);
+        }
+    }
+
+    /**
      * Rename the module directory to a temp location and return the temp path.
      * Returns null if the directory does not exist.
      */
@@ -306,9 +320,9 @@ class Installer extends LibraryInstaller
                     (new Filesystem)->removeDirectory($basePath);
                 }
             },
-            function (\Throwable $e) use ($stashPath, $basePath) {
+            function (\Throwable $e) use ($stashPath, $basePath, $initial) {
                 if ($stashPath !== null) {
-                    (new Filesystem)->removeDirectory($stashPath);
+                    $this->restoreStash($stashPath, $initial);
                 }
                 if ($basePath !== null) {
                     (new Filesystem)->removeDirectory($basePath);

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -256,7 +256,7 @@ class Installer extends LibraryInstaller
                 $this->io->writeError("  <warning>Merge conflict in $rel — conflict markers inserted</warning>");
             }
 
-            rename($merged, $newFile);
+            (new SymfonyFilesystem)->rename($merged, $newFile, true);
         }
     }
 

--- a/tests/ModuleInstallerTest.php
+++ b/tests/ModuleInstallerTest.php
@@ -53,6 +53,11 @@ final class TestableInstaller extends Installer
     {
         parent::mergeStash($stash, $base, $install);
     }
+
+    public function callRestoreStash(string $stashPath, PackageInterface $package): void
+    {
+        parent::restoreStash($stashPath, $package);
+    }
 }
 
 final class ModuleInstallerTest extends TestCase
@@ -378,5 +383,71 @@ final class ModuleInstallerTest extends TestCase
         $fs->remove($stash);
         $fs->remove($base);
         $fs->remove($install);
+    }
+
+    // -------------------------------------------------------------------------
+    // restoreStash
+    // -------------------------------------------------------------------------
+
+    public function test_restore_stash_renames_stash_back_when_original_path_missing(): void
+    {
+        $io = $this->createStub(IOInterface::class);
+        $composer = $this->createStub(Composer::class);
+
+        $root = new RootPackage('root/app', '1.0.0.0', '1.0.0');
+        $root->setExtra(['module-dir' => sys_get_temp_dir()]);
+        $composer->method('getPackage')->willReturn($root);
+
+        $installer = new TestableInstaller($io, $composer);
+
+        $stash = sys_get_temp_dir().'/module-stash-restore-test-'.uniqid('', true);
+        mkdir($stash);
+        file_put_contents($stash.'/custom.php', '<?php // user file');
+
+        $pkg = new Package('saucebase/test-module', '1.0.0.0', '1.0.0');
+
+        // The original install path does not exist (was cleared during update)
+        $originalPath = $installer->getInstallPath($pkg);
+        $this->assertDirectoryDoesNotExist($originalPath);
+
+        $installer->callRestoreStash($stash, $pkg);
+
+        $this->assertDirectoryDoesNotExist($stash);
+        $this->assertDirectoryExists($originalPath);
+        $this->assertFileExists($originalPath.'/custom.php');
+
+        (new Filesystem)->remove($originalPath);
+    }
+
+    public function test_restore_stash_discards_stash_when_original_path_already_exists(): void
+    {
+        $io = $this->createStub(IOInterface::class);
+        $composer = $this->createStub(Composer::class);
+
+        $root = new RootPackage('root/app', '1.0.0.0', '1.0.0');
+        $root->setExtra(['module-dir' => sys_get_temp_dir()]);
+        $composer->method('getPackage')->willReturn($root);
+
+        $installer = new TestableInstaller($io, $composer);
+
+        $pkg = new Package('saucebase/already-there', '1.0.0.0', '1.0.0');
+
+        // Pre-create the original path (partial update left it behind)
+        $originalPath = $installer->getInstallPath($pkg);
+        mkdir($originalPath, 0755, true);
+        file_put_contents($originalPath.'/partial.php', 'partial');
+
+        $stash = sys_get_temp_dir().'/module-stash-discard-test-'.uniqid('', true);
+        mkdir($stash);
+        file_put_contents($stash.'/custom.php', '<?php // user file');
+
+        $installer->callRestoreStash($stash, $pkg);
+
+        // Stash was discarded, original path (with partial content) remains
+        $this->assertDirectoryDoesNotExist($stash);
+        $this->assertDirectoryExists($originalPath);
+        $this->assertFileExists($originalPath.'/partial.php');
+
+        (new Filesystem)->remove($originalPath);
     }
 }


### PR DESCRIPTION
This pull request introduces improvements to the module installer’s update and restore logic, as well as compatibility enhancements and new test coverage. The most significant changes are the addition of a robust `restoreStash` method, updates to dependency requirements, and new tests to verify correct stash restoration behavior.

**Installer logic improvements:**

* Added a new protected method `restoreStash` to `Installer.php` that restores a stashed module directory to its original install path, or discards the stash if the original path already exists. This ensures correct handling of module updates and partial restores.
* Integrated `restoreStash` into the error handling flow of the installer, ensuring stashes are properly restored or discarded during rollback scenarios.
* Updated file renaming in stash merging to use `SymfonyFilesystem->rename`, improving reliability and atomicity.

**Compatibility updates:**

* Modified `composer.json` to allow `symfony/finder` and `symfony/process` versions ^7.0 or ^8.0, expanding compatibility with older Symfony versions. Also added a `version` field to the package metadata. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R3) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L15-R17)

**Testing enhancements:**

* Added tests for `restoreStash` in `ModuleInstallerTest.php`, covering both restoration when the original path is missing and stash discard when the original path already exists. This ensures the new logic is thoroughly validated. [[1]](diffhunk://#diff-1c4ad9a794cc3c9de41e4cd7aba567b1d603958a8a1fb12f0065968951af319bR56-R60) [[2]](diffhunk://#diff-1c4ad9a794cc3c9de41e4cd7aba567b1d603958a8a1fb12f0065968951af319bR387-R452)