### PR TITLE
fix!: standardize module directory naming to lowercase and update rel…

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -20,7 +20,7 @@ use Symfony\Component\Process\Process;
  */
 class Installer extends LibraryInstaller
 {
-    const DEFAULT_ROOT = 'Modules';
+    const DEFAULT_ROOT = 'modules';
 
     const DEFAULT_MODULE_TYPE = 'laravel-module';
 
@@ -59,10 +59,11 @@ class Installer extends LibraryInstaller
     }
 
     /**
-     * Get the module name, i.e. "saucebase/something-nice" will be transformed into "SomethingNice"
+     * Get the module directory name from the package name.
+     * "saucebase/something-nice" → "something-nice" (lowercase slug, hyphens preserved).
      *
-     * @param  PackageInterface  $package  Compose Package Interface
-     * @return string Module Name
+     * @param  PackageInterface  $package  Composer Package Interface
+     * @return string Module directory name
      *
      * @throws ModuleInstallerException
      */
@@ -74,13 +75,10 @@ class Installer extends LibraryInstaller
             throw new ModuleInstallerException("Invalid package name: $name");
         }
 
-        // Take only the part after the vendor (index 1)
-        [$vendor, $packageName] = explode('/', $name, 2);
+        // Take only the part after the vendor (index 1) and lowercase it
+        [, $packageName] = explode('/', $name, 2);
 
-        // Split by "-" and convert each segment to ucfirst
-        $parts = explode('-', $packageName);
-
-        return implode('', array_map('ucfirst', $parts));
+        return strtolower($packageName);
     }
 
     public function supports($packageType)

--- a/tests/ModuleInstallerTest.php
+++ b/tests/ModuleInstallerTest.php
@@ -91,13 +91,13 @@ final class ModuleInstallerTest extends TestCase
 
     public function test_get_install_path_uses_default_modules_dir_when_no_composer(): void
     {
-        // Composer is null -> should fall back to DEFAULT_ROOT ("Modules")
+        // Composer is null -> should fall back to DEFAULT_ROOT ("modules")
         $io = $this->createStub(IOInterface::class);
         $installer = new TestableInstaller($io, null);
 
         $pkg = new Package('saucebase/something-nice', '1.0.0.0', '1.0.0');
 
-        $this->assertSame('Modules/SomethingNice', $installer->getInstallPath($pkg));
+        $this->assertSame('modules/something-nice', $installer->getInstallPath($pkg));
     }
 
     public function test_get_install_path_uses_default_when_no_module_dir_in_extra(): void
@@ -113,7 +113,7 @@ final class ModuleInstallerTest extends TestCase
         $installer = new TestableInstaller($io, $composer);
         $pkg = new Package('vendor/awesome-toolkit', '1.0.0.0', '1.0.0');
 
-        $this->assertSame('Modules/AwesomeToolkit', $installer->getInstallPath($pkg));
+        $this->assertSame('modules/awesome-toolkit', $installer->getInstallPath($pkg));
     }
 
     public function test_get_install_path_honors_extra_module_dir(): void
@@ -128,7 +128,27 @@ final class ModuleInstallerTest extends TestCase
         $installer = new TestableInstaller($io, $composer);
         $pkg = new Package('vendor/awesome-toolkit', '1.0.0.0', '1.0.0');
 
-        $this->assertSame('CustomModules/AwesomeToolkit', $installer->getInstallPath($pkg));
+        $this->assertSame('CustomModules/awesome-toolkit', $installer->getInstallPath($pkg));
+    }
+
+    public function test_get_module_name_returns_lowercase_slug(): void
+    {
+        $io = $this->createStub(IOInterface::class);
+        $installer = new TestableInstaller($io, null);
+
+        $cases = [
+            'saucebase/auth' => 'auth',
+            'saucebase/billing' => 'billing',
+            'saucebase/my-module' => 'my-module',
+            'saucebase/some-CAPS' => 'some-caps',
+            'vendor/awesome-toolkit' => 'awesome-toolkit',
+        ];
+
+        foreach ($cases as $packageName => $expected) {
+            $pkg = $this->createStub(PackageInterface::class);
+            $pkg->method('getPrettyName')->willReturn($packageName);
+            $this->assertSame($expected, $installer->callGetModuleName($pkg), "Failed for: $packageName");
+        }
     }
 
     public function test_get_module_name_throws_on_invalid_pretty_name(): void


### PR DESCRIPTION
This pull request refactors how module directory names are generated and stored, standardizing them to use lowercase slugs with hyphens preserved (e.g., `something-nice` instead of `SomethingNice`). It updates both the implementation in `Installer.php` and the corresponding tests to reflect this change.

**Module naming and path generation changes:**

* The default root directory for modules is now lowercase (`modules` instead of `Modules`).
* Module directory names are now generated as lowercase slugs, preserving hyphens, rather than being converted to PascalCase. For example, `saucebase/something-nice` becomes `something-nice`.
* Updated method documentation in `Installer.php` to clarify that module directory names are lowercase slugs.

**Test updates:**

* Updated tests in `ModuleInstallerTest.php` to expect lowercase module directory names and root directory (`modules/something-nice` instead of `Modules/SomethingNice`). [[1]](diffhunk://#diff-1c4ad9a794cc3c9de41e4cd7aba567b1d603958a8a1fb12f0065968951af319bL94-R100) [[2]](diffhunk://#diff-1c4ad9a794cc3c9de41e4cd7aba567b1d603958a8a1fb12f0065968951af319bL116-R116) [[3]](diffhunk://#diff-1c4ad9a794cc3c9de41e4cd7aba567b1d603958a8a1fb12f0065968951af319bL131-R151)
* Added a new test to ensure `getModuleName` returns the expected lowercase slug for various package names.…ated tests