### PR TITLE
feat: add package registration logic for path repositories in install…

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -401,6 +401,10 @@ class Installer extends LibraryInstaller
         if ($this->isPathRepository($package)) {
             $this->io->write("  - <info>Skipping install for path repository:</info> {$package->getPrettyName()}");
 
+            if (! $repo->hasPackage($package)) {
+                $repo->addPackage(clone $package);
+            }
+
             return \React\Promise\resolve(null);
         }
 
@@ -479,6 +483,10 @@ class Installer extends LibraryInstaller
     {
         if ($this->isPathRepository($target)) {
             $this->io->write("  - <info>Skipping update for path repository:</info> {$target->getPrettyName()}");
+
+            if (! $repo->hasPackage($target)) {
+                $repo->addPackage(clone $target);
+            }
 
             return \React\Promise\resolve(null);
         }

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -484,6 +484,10 @@ class Installer extends LibraryInstaller
         if ($this->isPathRepository($target)) {
             $this->io->write("  - <info>Skipping update for path repository:</info> {$target->getPrettyName()}");
 
+            if ($repo->hasPackage($initial)) {
+                $repo->removePackage($initial);
+            }
+
             if (! $repo->hasPackage($target)) {
                 $repo->addPackage(clone $target);
             }

--- a/tests/ModuleInstallerTest.php
+++ b/tests/ModuleInstallerTest.php
@@ -668,6 +668,27 @@ final class ModuleInstallerTest extends TestCase
 
         $repo = $this->createMock(InstalledRepositoryInterface::class);
         $repo->method('hasPackage')->willReturn(false);
+        $repo->expects($this->never())->method('removePackage');
+        $repo->expects($this->once())->method('addPackage');
+
+        $installer = new TestableInstaller($io, null);
+        $installer->update($repo, $initial, $target);
+    }
+
+    public function test_update_replaces_initial_with_target_in_repo_for_path_repo(): void
+    {
+        $io = $this->createStub(IOInterface::class);
+
+        $initial = $this->createStub(PackageInterface::class);
+
+        $target = $this->createStub(PackageInterface::class);
+        $target->method('getDistType')->willReturn('path');
+        $target->method('getPrettyName')->willReturn('saucebase/test');
+
+        $repo = $this->createMock(InstalledRepositoryInterface::class);
+        $repo->method('hasPackage')
+            ->willReturnCallback(fn (PackageInterface $pkg) => $pkg === $initial);
+        $repo->expects($this->once())->method('removePackage')->with($initial);
         $repo->expects($this->once())->method('addPackage');
 
         $installer = new TestableInstaller($io, null);
@@ -686,6 +707,7 @@ final class ModuleInstallerTest extends TestCase
 
         $repo = $this->createMock(InstalledRepositoryInterface::class);
         $repo->method('hasPackage')->willReturn(true);
+        $repo->expects($this->once())->method('removePackage')->with($initial);
         $repo->expects($this->never())->method('addPackage');
 
         $installer = new TestableInstaller($io, null);

--- a/tests/ModuleInstallerTest.php
+++ b/tests/ModuleInstallerTest.php
@@ -599,6 +599,38 @@ final class ModuleInstallerTest extends TestCase
         $this->assertNotNull($promise);
     }
 
+    public function test_install_registers_package_in_repo_when_not_already_present_for_path_repo(): void
+    {
+        $io = $this->createStub(IOInterface::class);
+
+        $pkg = $this->createStub(PackageInterface::class);
+        $pkg->method('getDistType')->willReturn('path');
+        $pkg->method('getPrettyName')->willReturn('saucebase/test');
+
+        $repo = $this->createMock(InstalledRepositoryInterface::class);
+        $repo->method('hasPackage')->willReturn(false);
+        $repo->expects($this->once())->method('addPackage');
+
+        $installer = new TestableInstaller($io, null);
+        $installer->install($repo, $pkg);
+    }
+
+    public function test_install_does_not_register_package_in_repo_when_already_present_for_path_repo(): void
+    {
+        $io = $this->createStub(IOInterface::class);
+
+        $pkg = $this->createStub(PackageInterface::class);
+        $pkg->method('getDistType')->willReturn('path');
+        $pkg->method('getPrettyName')->willReturn('saucebase/test');
+
+        $repo = $this->createMock(InstalledRepositoryInterface::class);
+        $repo->method('hasPackage')->willReturn(true);
+        $repo->expects($this->never())->method('addPackage');
+
+        $installer = new TestableInstaller($io, null);
+        $installer->install($repo, $pkg);
+    }
+
     // -------------------------------------------------------------------------
     // update() path-repository guard
     // -------------------------------------------------------------------------
@@ -622,6 +654,42 @@ final class ModuleInstallerTest extends TestCase
         $promise = $installer->update($repo, $initial, $target);
 
         $this->assertNotNull($promise);
+    }
+
+    public function test_update_registers_package_in_repo_when_not_already_present_for_path_repo(): void
+    {
+        $io = $this->createStub(IOInterface::class);
+
+        $initial = $this->createStub(PackageInterface::class);
+
+        $target = $this->createStub(PackageInterface::class);
+        $target->method('getDistType')->willReturn('path');
+        $target->method('getPrettyName')->willReturn('saucebase/test');
+
+        $repo = $this->createMock(InstalledRepositoryInterface::class);
+        $repo->method('hasPackage')->willReturn(false);
+        $repo->expects($this->once())->method('addPackage');
+
+        $installer = new TestableInstaller($io, null);
+        $installer->update($repo, $initial, $target);
+    }
+
+    public function test_update_does_not_register_package_in_repo_when_already_present_for_path_repo(): void
+    {
+        $io = $this->createStub(IOInterface::class);
+
+        $initial = $this->createStub(PackageInterface::class);
+
+        $target = $this->createStub(PackageInterface::class);
+        $target->method('getDistType')->willReturn('path');
+        $target->method('getPrettyName')->willReturn('saucebase/test');
+
+        $repo = $this->createMock(InstalledRepositoryInterface::class);
+        $repo->method('hasPackage')->willReturn(true);
+        $repo->expects($this->never())->method('addPackage');
+
+        $installer = new TestableInstaller($io, null);
+        $installer->update($repo, $initial, $target);
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
This pull request improves the handling of path repository packages during installation and update, ensuring they are properly registered in the installed repository only if not already present. It also adds comprehensive tests to verify this behavior.

**Installer logic improvements:**

* Updated `install` and `update` methods in `Installer.php` to check if a path repository package is already present in the installed repository before adding it. If not present, the package is cloned and added; otherwise, it is skipped. [[1]](diffhunk://#diff-67306479da293f095927542c4cff1a45875138eb52372caaba982b07c053285bR404-R407) [[2]](diffhunk://#diff-67306479da293f095927542c4cff1a45875138eb52372caaba982b07c053285bR487-R490)

**Test coverage enhancements:**

* Added tests to `ModuleInstallerTest.php` to verify that path repository packages are registered in the repository only when not already present during both install and update operations. [[1]](diffhunk://#diff-1c4ad9a794cc3c9de41e4cd7aba567b1d603958a8a1fb12f0065968951af319bR602-R633) [[2]](diffhunk://#diff-1c4ad9a794cc3c9de41e4cd7aba567b1d603958a8a1fb12f0065968951af319bR659-R694)