### PR TITLE
fix: Add unit test for flattenFrameworkFiles to remove stale files

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -360,11 +360,38 @@ class Installer extends LibraryInstaller
      */
     protected function flattenFrameworkFiles(string $jsRoot, string $framework): void
     {
+        $targetPaths = [];
+        if (is_dir($jsRoot.'/'.$framework)) {
+            foreach ((new Finder)->files()->in($jsRoot.'/'.$framework) as $f) {
+                $targetPaths[$f->getRelativePathname()] = true;
+            }
+        }
+
+        $stale = [];
+        foreach (self::KNOWN_FRAMEWORKS as $fw) {
+            if ($fw === $framework || ! is_dir($jsRoot.'/'.$fw)) {
+                continue;
+            }
+            foreach ((new Finder)->files()->in($jsRoot.'/'.$fw) as $f) {
+                $rel = $f->getRelativePathname();
+                if (! isset($targetPaths[$rel])) {
+                    $stale[] = $rel;
+                }
+            }
+        }
+
         $this->copyDirectory($jsRoot.'/'.$framework, $jsRoot);
 
         $fs = new Filesystem;
         foreach (self::KNOWN_FRAMEWORKS as $fw) {
             $fs->removeDirectory($jsRoot.'/'.$fw);
+        }
+
+        $sfFs = new SymfonyFilesystem;
+        foreach ($stale as $rel) {
+            if (file_exists($jsRoot.'/'.$rel)) {
+                $sfFs->remove($jsRoot.'/'.$rel);
+            }
         }
     }
 

--- a/tests/ModuleInstallerTest.php
+++ b/tests/ModuleInstallerTest.php
@@ -1036,4 +1036,24 @@ final class ModuleInstallerTest extends TestCase
 
         return new TestableInstaller($io, $composer);
     }
+
+    public function test_flatten_framework_files_removes_stale_root_file_from_other_framework(): void
+    {
+        $jsRoot = sys_get_temp_dir().'/flatten-stale-'.uniqid('', true);
+        mkdir($jsRoot.'/vue', 0755, true);
+        mkdir($jsRoot.'/react', 0755, true);
+        file_put_contents($jsRoot.'/app.ts', 'stale vue root file');
+        file_put_contents($jsRoot.'/vue/app.ts', 'vue app');
+        file_put_contents($jsRoot.'/react/app.tsx', 'react app');
+
+        $installer = new TestableInstaller($this->createStub(IOInterface::class), null);
+        $installer->callFlattenFrameworkFiles($jsRoot, 'react');
+
+        $this->assertFileExists($jsRoot.'/app.tsx');
+        $this->assertFileDoesNotExist($jsRoot.'/app.ts');
+        $this->assertDirectoryDoesNotExist($jsRoot.'/vue');
+        $this->assertDirectoryDoesNotExist($jsRoot.'/react');
+
+        (new Filesystem)->remove($jsRoot);
+    }
 }


### PR DESCRIPTION
This pull request improves the handling of framework-specific files during the flattening process and adds a new test to ensure stale files from other frameworks are properly removed. The main changes focus on making sure that when copying files for a selected framework, any obsolete files from other frameworks are cleaned up from the root directory.

**Framework file flattening and cleanup:**

* Updated `flattenFrameworkFiles` in `Installer.php` to track and remove stale files from the root directory that belong to other frameworks, ensuring only the current framework's files remain after flattening.

**Testing improvements:**

* Added a new test `test_flatten_framework_files_removes_stale_root_file_from_other_framework` in `ModuleInstallerTest.php` to verify that stale root files from other frameworks are deleted and only the selected framework's files persist.