### PR TITLE
Refactor repository path logic and add locally tracked method

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -281,9 +281,6 @@ class Installer extends LibraryInstaller
      * Returns true when the package is served by a local path repository.
      * Path repos have source == install path, so the normal download/delete cycle would
      * wipe the user's files before trying to copy from the now-missing source.
-     *
-     * With symlink:true, a genuine path repo creates a real OS symlink. A module installed
-     * from Packagist into the same directory is a real directory — not a true path repo.
      */
     protected function isPathRepository(PackageInterface $package): bool
     {
@@ -291,9 +288,19 @@ class Installer extends LibraryInstaller
             return false;
         }
 
-        $path = $this->getInstallPath($package);
-        // Genuine path repos: OS symlink (symlink:true) OR a git-tracked dev clone (.git present).
-        // Packagist-installed modules have .git removed by DEFAULT_EXCLUDED_DIRS — they are neither.
+        return $this->isLocallyTracked($this->getInstallPath($package));
+    }
+
+    /**
+     * Returns true when the install path is a locally-managed directory that should never
+     * be overwritten by the installer — either an OS symlink (path repo with symlink:true)
+     * or a git-tracked dev clone (.git present).
+     *
+     * Packagist-installed modules have .git removed by DEFAULT_EXCLUDED_DIRS, so they never
+     * match this check and remain updateable from Packagist.
+     */
+    protected function isLocallyTracked(string $path): bool
+    {
         return is_link($path) || is_dir($path.'/.git');
     }
 


### PR DESCRIPTION
This pull request refactors the logic for detecting locally managed packages in the installer. The main change is the extraction of path repository detection into a new, more general method, improving code clarity and maintainability.

**Refactoring and logic improvement:**

* Extracted the logic for checking if a package is a path repository into a new method `isLocallyTracked`, which determines if a given install path is either a symlink or a git-tracked directory. The `isPathRepository` method now delegates to this new method for improved clarity and reusability.
* Updated and clarified documentation for both methods to better explain the distinction between genuine path repositories and Packagist-installed modules, and to document why certain paths are protected from being overwritten.