### PR TITLE
feat: add locally-tracked guard to install and update methods in Inst…

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -452,6 +452,16 @@ class Installer extends LibraryInstaller
             return \React\Promise\resolve(null);
         }
 
+        if ($this->isLocallyTracked($this->getInstallPath($package))) {
+            $this->io->write("  - <info>Skipping install for locally tracked module:</info> {$package->getPrettyName()}");
+
+            if (! $repo->hasPackage($package)) {
+                $repo->addPackage(clone $package);
+            }
+
+            return \React\Promise\resolve(null);
+        }
+
         $promise = $this->parentInstall($repo, $package);
 
         return $promise->then(function () use ($package) {
@@ -540,6 +550,20 @@ class Installer extends LibraryInstaller
         }
 
         $installPath = $this->getInstallPath($target);
+
+        if ($this->isLocallyTracked($installPath)) {
+            $this->io->write("  - <info>Skipping update for locally tracked module:</info> {$target->getPrettyName()}");
+
+            if ($repo->hasPackage($initial)) {
+                $repo->removePackage($initial);
+            }
+
+            if (! $repo->hasPackage($target)) {
+                $repo->addPackage(clone $target);
+            }
+
+            return \React\Promise\resolve(null);
+        }
         $stashPath = null;
         $basePath = null;
 

--- a/tests/ModuleInstallerTest.php
+++ b/tests/ModuleInstallerTest.php
@@ -675,6 +675,40 @@ final class ModuleInstallerTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // install() locally-tracked guard (distType='zip', physical .git check)
+    // -------------------------------------------------------------------------
+
+    public function test_install_skips_when_install_path_is_locally_tracked(): void
+    {
+        $baseDir = sys_get_temp_dir().'/install-tracked-'.uniqid('', true);
+        mkdir($baseDir.'/test-module/.git', 0755, true);
+
+        $io = $this->createMock(IOInterface::class);
+        $io->expects($this->once())
+            ->method('write')
+            ->with($this->stringContains('Skipping install for locally tracked'));
+
+        $composer = $this->createStub(Composer::class);
+        $root = new RootPackage('root/app', '1.0.0.0', '1.0.0');
+        $root->setExtra(['module-dir' => $baseDir]);
+        $composer->method('getPackage')->willReturn($root);
+
+        $pkg = new Package('saucebase/test-module', '1.0.0.0', '1.0.0');
+        $pkg->setDistType('zip');
+
+        $repo = $this->createMock(InstalledRepositoryInterface::class);
+        $repo->method('hasPackage')->willReturn(false);
+        $repo->expects($this->once())->method('addPackage');
+
+        $installer = new TestableInstaller($io, $composer);
+        $promise = $installer->install($repo, $pkg);
+
+        $this->assertNotNull($promise);
+
+        (new Filesystem)->remove($baseDir);
+    }
+
+    // -------------------------------------------------------------------------
     // update() path-repository guard
     // -------------------------------------------------------------------------
 
@@ -795,6 +829,42 @@ final class ModuleInstallerTest extends TestCase
         $installer = new TestableInstaller($io, null);
         $installer->forcePathRepository = true;
         $installer->uninstall($repo, $pkg);
+    }
+
+    // -------------------------------------------------------------------------
+    // update() locally-tracked guard (distType='zip', physical .git check)
+    // -------------------------------------------------------------------------
+
+    public function test_update_skips_when_install_path_is_locally_tracked(): void
+    {
+        $baseDir = sys_get_temp_dir().'/update-tracked-'.uniqid('', true);
+        mkdir($baseDir.'/test-module/.git', 0755, true);
+
+        $io = $this->createMock(IOInterface::class);
+        $io->expects($this->once())
+            ->method('write')
+            ->with($this->stringContains('Skipping update for locally tracked'));
+
+        $composer = $this->createStub(Composer::class);
+        $root = new RootPackage('root/app', '1.0.0.0', '1.0.0');
+        $root->setExtra(['module-dir' => $baseDir]);
+        $composer->method('getPackage')->willReturn($root);
+
+        $initial = new Package('saucebase/test-module', '1.0.0.0', '1.0.0');
+        $target = new Package('saucebase/test-module', '2.0.0.0', '2.0.0');
+        $target->setDistType('zip');
+
+        $repo = $this->createMock(InstalledRepositoryInterface::class);
+        $repo->method('hasPackage')->willReturnOnConsecutiveCalls(true, false);
+        $repo->expects($this->once())->method('removePackage');
+        $repo->expects($this->once())->method('addPackage');
+
+        $installer = new TestableInstaller($io, $composer);
+        $promise = $installer->update($repo, $initial, $target);
+
+        $this->assertNotNull($promise);
+
+        (new Filesystem)->remove($baseDir);
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces logic to skip installation and updating of modules that are locally tracked (i.e., have a `.git` directory), preventing Composer from overwriting local changes. Comprehensive tests are also added to ensure this behavior.

### Installer logic improvements

* [`src/Installer.php`](diffhunk://#diff-67306479da293f095927542c4cff1a45875138eb52372caaba982b07c053285bR455-R464): The `install` and `update` methods now detect if a module is locally tracked (by checking for a `.git` directory) and skip installation or update for such modules, logging a message to the user and ensuring repository state is consistent. [[1]](diffhunk://#diff-67306479da293f095927542c4cff1a45875138eb52372caaba982b07c053285bR455-R464) [[2]](diffhunk://#diff-67306479da293f095927542c4cff1a45875138eb52372caaba982b07c053285bR553-R566)

### Test coverage

* [`tests/ModuleInstallerTest.php`](diffhunk://#diff-1c4ad9a794cc3c9de41e4cd7aba567b1d603958a8a1fb12f0065968951af319bR677-R710): Added `test_install_skips_when_install_path_is_locally_tracked` to verify that installation is skipped for locally tracked modules and the correct message is output.
* [`tests/ModuleInstallerTest.php`](diffhunk://#diff-1c4ad9a794cc3c9de41e4cd7aba567b1d603958a8a1fb12f0065968951af319bR834-R869): Added `test_update_skips_when_install_path_is_locally_tracked` to verify that updates are skipped for locally tracked modules, the repository is updated appropriately, and the correct message is output.